### PR TITLE
提高gitment的浏览器兼容性

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": ["transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "homepage": "https://github.com/imsun/gitment",
   "scripts": {
     "build": "babel src --out-dir dist --ignore test.js --source-maps & cross-env NODE_ENV=production webpack --config webpack.config.js --progress --profile --colors",
-    "dev": "webpack-dev-server --config webpack.dev.config.js --host 0.0.0.0 --progress --profile --colors"
+    "dev": "webpack-dev-server --config webpack.dev.config.js --host 0.0.0.0 --progress --profile --colors",
+    "dist": "babel src --out-dir dist --ignore test.js --source-maps & webpack --config webpack.config.js -p"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "babel src --out-dir dist --ignore test.js --source-maps & cross-env NODE_ENV=production webpack --config webpack.config.js --progress --profile --colors",
     "dev": "webpack-dev-server --config webpack.dev.config.js --host 0.0.0.0 --progress --profile --colors",
-    "dist": "babel src --out-dir dist --ignore test.js --source-maps & webpack --config webpack.config.js -p"
+    "postbuild": "babel src --out-dir dist --ignore test.js --source-maps & webpack --config webpack.config.js -p --env.production"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
@@ -35,6 +35,7 @@
     "webpack-dev-server": "^2.4.2"
   },
   "dependencies": {
+    "babel-runtime": "^6.23.0",
     "mobx": "^3.1.7"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,8 @@
   },
   "homepage": "https://github.com/imsun/gitment",
   "scripts": {
-    "build": "babel src --out-dir dist --ignore test.js --source-maps & cross-env NODE_ENV=production webpack --config webpack.config.js --progress --profile --colors",
-    "dev": "webpack-dev-server --config webpack.dev.config.js --host 0.0.0.0 --progress --profile --colors",
-    "postbuild": "babel src --out-dir dist --ignore test.js --source-maps & webpack --config webpack.config.js -p --env.production"
+    "build": "babel src --out-dir dist --ignore test.js --source-maps & webpack --progress --profile --colors & cross-env NODE_ENV=production webpack -p",
+    "dev": "webpack-dev-server --config webpack.dev.config.js --host 0.0.0.0 --progress --profile --colors"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
   },
   "homepage": "https://github.com/imsun/gitment",
   "scripts": {
-    "build": "babel src --out-dir dist --ignore test.js --source-maps & NODE_ENV=production webpack --config webpack.config.js --progress --profile --colors",
+    "build": "babel src --out-dir dist --ignore test.js --source-maps & cross-env NODE_ENV=production webpack --config webpack.config.js --progress --profile --colors",
     "dev": "webpack-dev-server --config webpack.dev.config.js --host 0.0.0.0 --progress --profile --colors"
   },
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.1",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-es2015": "^6.24.0",
+    "cross-env": "^5.0.1",
     "webpack": "^2.3.2",
     "webpack-dev-server": "^2.4.2"
   },

--- a/src/gitment.js
+++ b/src/gitment.js
@@ -55,7 +55,7 @@ class Gitment {
       perPage: 20,
       maxCommentHeight: 250,
     }, options)
-    this.theme = Object.assign({},defaultTheme,options.theme);
+    this.theme = Object.assign({}, defaultTheme, options.theme)
     this.useTheme(this.theme)
 
     const user = {}

--- a/src/gitment.js
+++ b/src/gitment.js
@@ -9,8 +9,7 @@ const scope = 'public_repo'
 function extendRenderer(instance, renderer) {
   instance[renderer] = (container) => {
     const targetContainer = getTargetContainer(container)
-    const render = instance.theme[renderer] || instance.defaultTheme[renderer]
-
+    const render = instance.theme[renderer]
     autorun(() => {
       const e = render(instance.state, instance)
       if (targetContainer.firstChild) {
@@ -46,20 +45,17 @@ class Gitment {
 
   constructor(options = {}) {
     this.defaultTheme = defaultTheme
-    this.useTheme(defaultTheme)
-
     Object.assign(this, {
       id: window.location.href,
       title: window.document.title,
       link: window.location.href,
       desc: '',
       labels: [],
-      theme: defaultTheme,
       oauth: {},
       perPage: 20,
       maxCommentHeight: 250,
     }, options)
-
+    this.theme = Object.assign({},defaultTheme,options.theme);
     this.useTheme(this.theme)
 
     const user = {}
@@ -127,10 +123,9 @@ class Gitment {
   }
 
   useTheme(theme = {}) {
-    this.theme = theme
-
-    const renderers = Object.keys(this.theme)
-    renderers.forEach(renderer => extendRenderer(this, renderer))
+    const renderers = Object.keys(theme)
+    renderers.forEach(renderer => this[renderer]=this.theme[renderer])
+    extendRenderer(this,'render')
   }
 
   update() {

--- a/src/gitment.js
+++ b/src/gitment.js
@@ -124,8 +124,7 @@ class Gitment {
 
   useTheme(theme = {}) {
     const renderers = Object.keys(theme)
-    renderers.forEach(renderer => this[renderer]=this.theme[renderer])
-    extendRenderer(this,'render')
+    renderers.forEach(renderer => extendRenderer(this,renderer))
   }
 
   update() {

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -336,10 +336,10 @@ function render(state, instance) {
   const container = document.createElement('div')
   container.lang = "en-US"
   container.className = 'gitment-container gitment-root-container'
-  container.appendChild(renderHeader(state, instance))
-  container.appendChild(renderComments(state, instance))
-  container.appendChild(renderEditor(state, instance))
-  container.appendChild(renderFooter(state, instance))
+  container.appendChild(instance.renderHeader(state, instance))
+  container.appendChild(instance.renderComments(state, instance))
+  container.appendChild(instance.renderEditor(state, instance))
+  container.appendChild(instance.renderFooter(state, instance))
   return container
 }
 

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -336,10 +336,10 @@ function render(state, instance) {
   const container = document.createElement('div')
   container.lang = "en-US"
   container.className = 'gitment-container gitment-root-container'
-  container.appendChild(instance.theme.renderHeader(state, instance))
-  container.appendChild(instance.theme.renderComments(state, instance))
-  container.appendChild(instance.theme.renderEditor(state, instance))
-  container.appendChild(instance.theme.renderFooter(state, instance))
+  container.appendChild(instance.renderHeader(state, instance))
+  container.appendChild(instance.renderComments(state, instance))
+  container.appendChild(instance.renderEditor(state, instance))
+  container.appendChild(instance.renderFooter(state, instance))
   return container
 }
 

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -336,10 +336,10 @@ function render(state, instance) {
   const container = document.createElement('div')
   container.lang = "en-US"
   container.className = 'gitment-container gitment-root-container'
-  container.appendChild(instance.renderHeader(state, instance))
-  container.appendChild(instance.renderComments(state, instance))
-  container.appendChild(instance.renderEditor(state, instance))
-  container.appendChild(instance.renderFooter(state, instance))
+  container.appendChild(instance.theme.renderHeader(state, instance))
+  container.appendChild(instance.theme.renderComments(state, instance))
+  container.appendChild(instance.theme.renderEditor(state, instance))
+  container.appendChild(instance.theme.renderFooter(state, instance))
   return container
 }
 

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -79,7 +79,6 @@ function renderComments({ meta, comments, commentReactions, currentPage, user, e
       initHint.appendChild(initButton)
       errorBlock.appendChild(initHint)
     } else {
-      console.log('error object',error);
       errorBlock.innerText = error
     }
     container.appendChild(errorBlock)

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -30,6 +30,7 @@ function renderHeader({ meta, user, reactions }, instance) {
     likeButton.classList.remove('liked')
     likeButton.onclick = () => instance.like()
   }
+
   container.appendChild(likeButton)
 
   const commentsCount = document.createElement('span')
@@ -78,6 +79,7 @@ function renderComments({ meta, comments, commentReactions, currentPage, user, e
       initHint.appendChild(initButton)
       errorBlock.appendChild(initHint)
     } else {
+      console.log('error object',error);
       errorBlock.innerText = error
     }
     container.appendChild(errorBlock)
@@ -335,10 +337,10 @@ function render(state, instance) {
   const container = document.createElement('div')
   container.lang = "en-US"
   container.className = 'gitment-container gitment-root-container'
-  container.appendChild(instance.renderHeader(state, instance))
-  container.appendChild(instance.renderComments(state, instance))
-  container.appendChild(instance.renderEditor(state, instance))
-  container.appendChild(instance.renderFooter(state, instance))
+  container.appendChild(renderHeader(state, instance))
+  container.appendChild(renderComments(state, instance))
+  container.appendChild(renderEditor(state, instance))
+  container.appendChild(renderFooter(state, instance))
   return container
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 import { LS_ACCESS_TOKEN_KEY } from './constants'
 
-export const isString = s => toString.call(s) === '[object String]'
+export const isString = s => ({}).toString.call(s) === '[object String]'
 
 export function getTargetContainer(container) {
   let targetContainer

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = function (env) {
     devtool: 'source-map',
     output: {
       path: path.join(__dirname, 'dist'),
-      filename: (env&&env.production) ? 'gitment.browser.min.js' : 'gitment.browser.js',
+      filename: (env && env.production) ? 'gitment.browser.min.js' : 'gitment.browser.js',
       libraryTarget: 'var',
       library: 'Gitment',
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path')
-
+const PROD = process.env.NODE_ENV === 'production'
 module.exports = function (env) {
   return {
     context: path.join(__dirname, 'src'),
@@ -7,7 +7,7 @@ module.exports = function (env) {
     devtool: 'source-map',
     output: {
       path: path.join(__dirname, 'dist'),
-      filename: (env && env.production) ? 'gitment.browser.min.js' : 'gitment.browser.js',
+      filename: PROD ? 'gitment.browser.min.js' : 'gitment.browser.js',
       libraryTarget: 'var',
       library: 'Gitment',
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,22 +1,24 @@
 const path = require('path')
 
-module.exports = {
-  context: path.join(__dirname, 'src'),
-  entry: './gitment.js',
-  devtool: 'source-map',
-  output: {
-    path: path.join(__dirname, 'dist'),
-    filename: 'gitment.browser.js',
-    libraryTarget: 'var',
-    library: 'Gitment',
-  },
-  module: {
-    loaders: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        loaders: ['babel-loader'],
-      },
-    ],
-  },
-}
+module.exports = function (env) {
+  return {
+    context: path.join(__dirname, 'src'),
+    entry: './gitment.js',
+    devtool: 'source-map',
+    output: {
+      path: path.join(__dirname, 'dist'),
+      filename: (env&&env.production)?'gitment.browser.min.js':'gitment.browser.js',
+      libraryTarget: 'var',
+      library: 'Gitment',
+    },
+    module: {
+      loaders: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loaders: ['babel-loader'],
+        },
+      ],
+    },
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        exclude: /^node_mocules/,
+        exclude: /node_modules/,
         loaders: ['babel-loader'],
       },
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = function (env) {
     devtool: 'source-map',
     output: {
       path: path.join(__dirname, 'dist'),
-      filename: (env&&env.production)?'gitment.browser.min.js':'gitment.browser.js',
+      filename: (env&&env.production) ? 'gitment.browser.min.js' : 'gitment.browser.js',
       libraryTarget: 'var',
       library: 'Gitment',
     },

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -13,7 +13,7 @@ module.exports = {
     loaders: [
       {
         test: /\.js$/,
-        exclude: /^node_mocules/,
+        exclude: /^node_modules/,
         loaders: ['babel-loader'],
       },
     ],


### PR DESCRIPTION
#### 所做的修改

- [x] 配置文件以及源文件：增加babel对`Promise`以及`Object.assign`的转换，增强浏览器的兼容，可以兼容到IE10(但是样式可能会错乱)

- [x] `npm script`以及跨平台脚本(使用了cross-env)：方便`npm run build`后直接生成`gitment.browser.js`以及`gitment.browser.min.js`