### PR TITLE
loadMeta时带上时间戳强制拉取新数据

### DIFF
--- a/src/gitment.js
+++ b/src/gitment.js
@@ -187,6 +187,7 @@ class Gitment {
     return http.get(`/repos/${owner}/${repo}/issues`, {
         creator: owner,
         labels: id,
+        t:new Date().getTime(),
       })
       .then(issues => {
         if (!issues.length) return Promise.reject(NOT_INITIALIZED_ERROR)


### PR DESCRIPTION
Chrome会缓存接口数据，导致刷新页面后依然显示未初始化。