### PR TITLE
add organization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ gitment.render('comments')
 
 ### 4. Initialize Your Comments
 
-After the page published, you should visit your page, login with your GitHub account(make sure you're repo's owner), and click the initialize button, to create a related issue in your repo.
+After the page published, you should visit your page, login with your GitHub account(make sure you're repo's owner or admin of organization's repo), and click the initialize button, to create a related issue in your repo.
 After that, others can leave their comments.
-   
+
 ## Methods
 
 ### constructor(options)
@@ -93,6 +93,7 @@ After that, others can leave their comments.
 Type: `object` 
 
 - owner: Your GitHub ID. Required.
+- admin: A string array of organization repository adminstratories, Make sure them are repo's admin or can write into organization's repo.
 - repo: The repository to store your comments. Make sure you're repo's owner. Required.
 - oauth: An object contains your client ID and client secret. Required.
     - client_id: GitHub client ID. Required.
@@ -207,7 +208,7 @@ You can inspect the DOM structure in the browser and write your own styles.
 ### Write A Theme
 
 A Gitment theme is an object contains several render functions.
- 
+
 By default Gitment has five render functions: `render`, `renderHeader`, `renderComments`, `renderEditor`, `renderFooter`.
 The last four render independent components and `render` function renders them together.
 All of them can be used independently.

--- a/src/gitment.js
+++ b/src/gitment.js
@@ -185,10 +185,14 @@ class Gitment {
   loadMeta() {
     const { id, owner, repo } = this
     return http.get(`/repos/${owner}/${repo}/issues`, {
-        creator: owner,
         labels: id,
       })
       .then(issues => {
+        if (issues.length) {
+          let allowed = (admin || [owner]).map(x=>x.toLowerCase())
+          issues = issues.filter(issue => ~allowed.indexOf(issue.user.login.toLowerCase()))
+            .sort((left, right) => new Date(left.created_at) - new Date(right.created_at))
+        }
         if (!issues.length) return Promise.reject(NOT_INITIALIZED_ERROR)
         this.state.meta = issues[0]
         return issues[0]

--- a/src/theme/default.js
+++ b/src/theme/default.js
@@ -62,7 +62,7 @@ function renderComments({ meta, comments, commentReactions, currentPage, user, e
 
     if (error === NOT_INITIALIZED_ERROR
       && user.login
-      && user.login.toLowerCase() === instance.owner.toLowerCase()) {
+      && ~(instance.admin || [instance.owner]).map(x=>x.toLowerCase()).indexOf(user.login.toLowerCase())) {
       const initHint = document.createElement('div')
       const initButton = document.createElement('button')
       initButton.className = 'gitment-comments-init-btn'


### PR DESCRIPTION
The option `admin` is string array, support a set of organization repository's administratories. the string array ignore lower/uppercase, and anyone can initialize your post's comments. so them need have write/create-issues access of organization repository. ex:

```
const gitment = new Gitment({
  owner: 'GitHub ID of organization repository',
  admin: ['user1', 'user2'],
  ...
```