### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ which can be used in the frontend without any server-side implementation.
 <script src="https://imsun.github.io/gitment/dist/gitment.browser.js"></script>
 ```
 
+or via CDN:
+
+```html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitment/style/default.css">
+```
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/gitment/dist/gitment.browser.js"></script>
+```
+
 or via npm:
 
 ```sh


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/gitment) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available, built specifically for production usage and also with very good coverage in China.